### PR TITLE
Reference v1.0.x for downloading bootstrap-sync script

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ timeout(120) {
           export DWNSTM_BRANCH=''' + DWNSTM_BRANCH + '''
           export CRW_KEYTAB=''' + CRW_KEYTAB + '''
           export USER=''' + USER + '''
-          curl -L -s -S https://raw.githubusercontent.com/redhat-developer/web-terminal-operator/master/bootstrap-sync.sh -o ./sync.sh
+          curl -L -s -S https://raw.githubusercontent.com/redhat-developer/web-terminal-operator/v1.0.x/bootstrap-sync.sh -o ./sync.sh
           chmod +x ./sync.sh
           ./sync.sh
 


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR makes the jenkinsfiles grab the scripts from v1.0.x since we no longer use master

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
