### PR TITLE
Add github action for creating next dockerimage

### DIFF
--- a/.github/workflows/dockerimage-next.yaml
+++ b/.github/workflows/dockerimage-next.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2020-2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Next Dockerimage
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout web-terminal-exec source code
+      uses: actions/checkout@v2
+
+    - name: Docker Build & Push
+      uses: docker/build-push-action@v1.1.0
+      with:
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+        registry: quay.io
+        repository: wto/web-terminal-exec
+        dockerfile: ./build/dockerfiles/Dockerfile
+        tags: next
+        tag_with_sha: true


### PR DESCRIPTION
Signed-off-by: Josh Pinkney <joshpinkney@gmail.com>

### What does this PR do?
This PR adds a github action so that web-terminal-exec is automatically pushed to quay on every change in main

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
