### PR TITLE
Change dockerfile base image and login to quay securely

### DIFF
--- a/.github/workflows/dockerimage-next.yaml
+++ b/.github/workflows/dockerimage-next.yaml
@@ -20,13 +20,14 @@ jobs:
     - name: Checkout web-terminal-exec source code
       uses: actions/checkout@v2
 
-    - name: Docker Build & Push
-      uses: docker/build-push-action@v1.1.0
-      with:
-        username: ${{ secrets.QUAY_USERNAME }}
-        password: ${{ secrets.QUAY_PASSWORD }}
-        registry: quay.io
-        repository: wto/web-terminal-exec
-        dockerfile: ./build/dockerfiles/Dockerfile
-        tags: next
-        tag_with_sha: true
+    - name: "Docker Quay.io Login with WTO Robot"
+      env:
+        DOCKER_USERNAME: ${{ secrets.QUAY_USERNAME }}
+        DOCKER_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+      run: |
+        echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin quay.io
+    
+    - name: "Docker build and push"
+      run: |
+        docker build -f ./build/dockerfiles/Dockerfile -t quay.io/wto/web-terminal-exec:next .
+        docker push quay.io/wto/web-terminal-exec:next

--- a/build/dockerfiles/Dockerfile
+++ b/build/dockerfiles/Dockerfile
@@ -9,8 +9,8 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/rhel8/go-toolset
-FROM rhel8/go-toolset:1.13.4-27 as builder
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/go-toolset
+FROM registry.access.redhat.com/ubi8/go-toolset:1.14.12 as builder
 ENV GOPATH=/go/
 USER root
 WORKDIR /che-machine-exec/


### PR DESCRIPTION
### What does this PR do?
This PR does 2 things:
1. Changes the dockerfile base image to the ubi8/go-toolset one so you don't have to authenticate (we don't even use this Dockerfile at all in downstream, this is purely for publishing the next version on quay)
2. Tweak the github action to make the login more secure

### What issues does this PR fix or reference?


### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
