### PR TITLE
Rebuild web-terminal-exec image nightly

### DIFF
--- a/.github/workflows/next-build.yaml
+++ b/.github/workflows/next-build.yaml
@@ -14,6 +14,8 @@ name: Machine Exec Next Build
 on:
   push:
     branches: [ main ]
+  schedule:
+    - cron: "0 0 * * *"
 jobs:
   build-push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What does this PR do?
Since this repo is not updated frequently, it looks like the public dockerimages for it are severely out of date: https://quay.io/repository/wto/web-terminal-exec?tab=tags&tag=latest. In addition to building on every commit, we should build nightly to ensure images are recent.

### What issues does this PR fix or reference?
N/A

### Is it tested? How?
N/A
