### PR TITLE
Fix issue creating kubeconfig for users with numeric names

### DIFF
--- a/.github/workflows/dockerimage-next.yaml
+++ b/.github/workflows/dockerimage-next.yaml
@@ -6,6 +6,9 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+
 name: Next Dockerimage
 
 on:

--- a/cico_build_ci.sh
+++ b/cico_build_ci.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 #
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2021 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
 #
 # SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
 #
 
 # Output command before executing

--- a/cico_build_nightly.sh
+++ b/cico_build_nightly.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 #
-# Copyright (c) 2019 Red Hat, Inc.
+# Copyright (c) 2019-2021 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
 #
 # SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
 #
 
 # Output command before executing

--- a/cico_build_release.sh
+++ b/cico_build_release.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 #
-# Copyright (c) 2012-2019 Red Hat, Inc.
+# Copyright (c) 2019-2021 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
 #
 # SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
 #
 
 # Output command before executing

--- a/cico_functions.sh
+++ b/cico_functions.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 #
-# Copyright (c) 2018-2020 Red Hat, Inc.
+# Copyright (c) 2019-2021 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
 #
 # SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
 #
 
 # Output command before executing

--- a/kubeconfig/kubeconfig.go
+++ b/kubeconfig/kubeconfig.go
@@ -171,7 +171,8 @@ func createKubeConfigDir(cmdRslv execInfo.InfoExecCreator, kubeconfigDir string,
 }
 
 func syncKubeConfig(cmdRslv execInfo.InfoExecCreator, config string, kubeconfigLocation string, containerInfo *model.ContainerInfo) error {
-	infoExec := cmdRslv.CreateInfoExec([]string{"sh", "-c", "echo \"" + config + "\" > " + kubeconfigLocation + "/config"}, containerInfo)
+	createCommand := fmt.Sprintf(`echo '%s' > %s/config`, config, kubeconfigLocation)
+	infoExec := cmdRslv.CreateInfoExec([]string{"sh", "-c", createCommand}, containerInfo)
 	if err := infoExec.Start(); err != nil {
 		logrus.Debugf("Could not write kubeconfig to %s in %s/%s. Error: %s", kubeconfigLocation, containerInfo.PodName, containerInfo.ContainerName, err.Error())
 		return errors.New("Could not write kubeconfig to: " + kubeconfigLocation)

--- a/scripts/license.sh
+++ b/scripts/license.sh
@@ -14,7 +14,7 @@ export ROOT_DIR=$(dirname $(dirname $(readlink -f "$0")));
 # Validate a Eclipse Che license header
 function validateChectlLicenseHeader() {
     python "${ROOT_DIR}"/scripts/validate-license.py $(find "${ROOT_DIR}" -type d \( -path "${ROOT_DIR}"/vendor -o -path "${ROOT_DIR}"/templates \) -prune -false \
-        -o -name '*.sh' -o -name '*.ts' -o -name '*.yml' -o -name '*.yaml' -o -name '*.go' \
+        -o -name '*.sh' -o -name '*.ts' -o -name '*.go' \
         | grep -v vendor \
         | grep -v mocks)
 }


### PR DESCRIPTION
### What does this PR do?
When creating a kubeconfig in the tooling container on an /exec/init call, we were using

  echo "<config>" > $KUBECONFIG

Using double-quotes in the echo resulted in stripping all double quotes out of the actual config string. Normally this would not cause an issue as alphanumeric strings are parsed as strings in yaml even without quotes, but for users whose names contain only numbers (or are formatted to be parsed as numbers, e.g. 0xbeef), this meant that the kubeconfig was invalid as it expects a string for username instead of a number.

Instead we cleanup the formatting for that exec command and instead enclose it in single quotes, which are unused by the yaml marshaller.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/WTO-153

### Is it tested? How?
Create a user with username `123456` in the cluster and attempt to start a web terminal. An image built off of these changes is available at `quay.io/amisevsk/web-terminal-exec:numeric-username`
