### PR TITLE
Add limits to requests processed by server

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/redhat-developer/web-terminal-exec/pkg/activity"
 	"github.com/redhat-developer/web-terminal-exec/pkg/config"
+	"github.com/redhat-developer/web-terminal-exec/pkg/constants"
 	"github.com/redhat-developer/web-terminal-exec/pkg/handler"
 	"github.com/redhat-developer/web-terminal-exec/pkg/operations"
 	"github.com/sirupsen/logrus"
@@ -46,7 +47,15 @@ func main() {
 		ActivityManager: activityManager,
 		ClientProvider:  clientProvider,
 	}
-	if err := http.ListenAndServeTLS(config.URL, TLSCertFile, TLSKeyFile, router.HTTPSHandler()); err != nil {
+
+	server := http.Server{
+		Addr:           config.URL,
+		Handler:        router.HTTPSHandler(),
+		ReadTimeout:    constants.ServerReadTimeout,
+		WriteTimeout:   constants.ServerWriteTimeout,
+		MaxHeaderBytes: constants.MaxHeaderBytes,
+	}
+	if err := server.ListenAndServeTLS(TLSCertFile, TLSKeyFile); err != nil {
 		logrus.Errorf("Failed to start server with TLS enabled: %s", err)
 	}
 }

--- a/pkg/constants/limits.go
+++ b/pkg/constants/limits.go
@@ -10,6 +10,11 @@
 
 package constants
 
+import "time"
+
 const (
-	MaxBodyBytes = 1024 * 1024 // 1 MiB
+	MaxBodyBytes       = 1 << 20  // 1 MiB
+	MaxHeaderBytes     = 16 << 10 // 16 KiB
+	ServerReadTimeout  = 3 * time.Second
+	ServerWriteTimeout = 3 * time.Second
 )

--- a/pkg/constants/limits.go
+++ b/pkg/constants/limits.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2019-2023 Red Hat, Inc.
+// This program and the accompanying materials are made
+// available under the terms of the Eclipse Public License 2.0
+// which is available at https://www.eclipse.org/legal/epl-2.0/
+//
+// SPDX-License-Identifier: EPL-2.0
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+
+package constants
+
+const (
+	MaxBodyBytes = 1024 * 1024 // 1 MiB
+)


### PR DESCRIPTION
### What does this PR do?
* Limit body size for requests to 1MiB
* Decrease max headers size (from default = 1MiB) to 8KiB
* Set read/write timeouts on server

### What issues does this PR fix or reference?

### Is it tested? How?
I tested by arbitrarily setting values of constants smaller and attempting requests.
