### PR TITLE
Update base images for container build

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/go-toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.19.6-4 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.20.12-2 as builder
 ENV GOPATH=/go/
 USER root
 WORKDIR /web-terminal-exec
@@ -18,7 +18,7 @@ COPY . .
 RUN make compile
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.8-860
+FROM registry.access.redhat.com/ubi8-minimal:8.9-1137
 RUN microdnf -y update && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 WORKDIR /
 COPY --from=builder /web-terminal-exec/_output/bin/web-terminal-exec /usr/local/bin/web-terminal-exec


### PR DESCRIPTION
### What does this PR do?
Update base images for container build to be in sync with [web-terminal operator repo
](https://github.com/redhat-developer/web-terminal-operator/pull/157)
### What issues does this PR fix or reference?
n/a

### Is it tested? How?
Ensure exec container builds: run `make docker-build`
