### PR TITLE
Update base images for container build for WTO 1.11

### DIFF
--- a/.github/workflows/next-container-build.yaml
+++ b/.github/workflows/next-container-build.yaml
@@ -25,7 +25,7 @@ jobs:
       git-sha: ${{ steps.git-sha.outputs.sha }}
 
     steps:
-    - name: Checkout devworkspace-operator source code
+    - name: Checkout web-terminal-exec source code
       uses: actions/checkout@v2
 
     - name: Set output for Git short SHA

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -25,7 +25,7 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.4
+        go-version: 1.21.10
     -
       name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8/go-toolset
-FROM registry.access.redhat.com/ubi8/go-toolset:1.20.12-2 as builder
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9/go-toolset
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21.10-1.1719562237 AS builder
 ENV GOPATH=/go/
 USER root
 WORKDIR /web-terminal-exec
@@ -17,8 +17,8 @@ COPY . .
 # Compile Web Terminal Exec binary
 RUN make compile
 
-# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
-FROM registry.access.redhat.com/ubi8-minimal:8.9-1137
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9-minimal
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4-1134
 RUN microdnf -y update && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 WORKDIR /
 COPY --from=builder /web-terminal-exec/_output/bin/web-terminal-exec /usr/local/bin/web-terminal-exec


### PR DESCRIPTION
### What does this PR do?
- Updates base images for container build to be in sync with the [web-terminal operator repo](https://github.com/redhat-developer/web-terminal-operator/pull/169)
- Fixes a typo in the next-container-build workflow
- Updates the version of golang used in the pr-check to match the version of golang used in the Dockerfile (go 1.21.10)
### What issues does this PR fix or reference?
n/a

### Is it tested? How?
Ensure the exec container builds: run `make docker-build`
