### PR TITLE
Update base images used in web terminal exec container for WTO 1.12

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -25,7 +25,7 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.21.10
+        go-version: 1.21.13
     -
       name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9/go-toolset
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21.10-1.1719562237 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21.13-2.1727893526 AS builder
 ENV GOPATH=/go/
 USER root
 WORKDIR /web-terminal-exec
@@ -18,7 +18,7 @@ COPY . .
 RUN make compile
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9-minimal
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4-1134
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4-1227.1726694542
 RUN microdnf -y update && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 WORKDIR /
 COPY --from=builder /web-terminal-exec/_output/bin/web-terminal-exec /usr/local/bin/web-terminal-exec


### PR DESCRIPTION
### What does this PR do?
- Updates base images for container build to be in sync with the web-terminal operator repo
- Updates the version of golang used in the pr-check to match the version of golang used in the Dockerfile (go v1.21.13)

### What issues does this PR fix or reference?
n/a

### Is it tested? How?
Ensure the exec container builds: run `make docker-build`. This should be validated automatically by the Validate PRs workflow