### PR TITLE
Update server timeouts

### DIFF
--- a/pkg/constants/limits.go
+++ b/pkg/constants/limits.go
@@ -15,6 +15,6 @@ import "time"
 const (
 	MaxBodyBytes       = 1 << 20  // 1 MiB
 	MaxHeaderBytes     = 16 << 10 // 16 KiB
-	ServerReadTimeout  = 3 * time.Second
-	ServerWriteTimeout = 3 * time.Second
+	ServerReadTimeout  = 10 * time.Second
+	ServerWriteTimeout = 10 * time.Second
 )


### PR DESCRIPTION
### What does this PR do?
Updates the server timeouts to 10s.

### What issues does this PR fix or reference?
The timeouts were set to 3 seconds however, this timeout can be too small for the [`/exec/init`](https://github.com/redhat-developer/web-terminal-exec/blob/295b4947f16e232369a2e7744316373a7202c250/pkg/handler/common.go#L47) endpoint if pod exec is slow on the cluster.

Related issue: https://issues.redhat.com/browse/WTO-313

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->
