### PR TITLE
chore : Add Devfile for web-terminal-exec with Makefile-based workflow commands

### DIFF
--- a/.devfile.yaml
+++ b/.devfile.yaml
@@ -1,0 +1,90 @@
+#
+# Copyright (c) 2019-2025 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+schemaVersion: 2.2.0
+metadata:
+  name: web-terminal-exec
+components:
+  - name: tools
+    container:
+      image: quay.io/devfile/universal-developer-image:ubi9-latest
+      memoryRequest: 1Gi
+      memoryLimit: 16Gi
+      cpuLimit: '4'
+      cpuRequest: '0.5'
+      env:
+        - name: DOCKER
+          value: podman
+commands:
+  - id: help
+    exec:
+      label: "List available make targets"
+      component: tools
+      commandLine: make help
+      group:
+        kind: build
+  - id: fmt
+    exec:
+      label: "Format all Go code"
+      component: tools
+      commandLine: make fmt
+      group:
+        kind: build
+  - id: fmt-license
+    exec:
+      label: "Add license headers to Go files"
+      component: tools
+      commandLine: |
+        go install github.com/google/addlicense@latest &&
+        make fmt_license
+      group:
+        kind: build
+  - id: check-fmt
+    exec:
+      label: "Check formatting and license headers"
+      component: tools
+      commandLine: |
+        go install golang.org/x/tools/cmd/goimports@latest &&
+        make check_fmt
+      group:
+        kind: test
+  - id: test
+    exec:
+      label: "Run Go tests and generate coverage"
+      component: tools
+      commandLine: make test
+      group:
+        kind: test
+  - id: vet
+    exec:
+      label: "Run go vet on source code"
+      component: tools
+      commandLine: make vet
+      group:
+        kind: test
+  - id: docker
+    exec:
+      label: "Build and push web-terminal-exec container image"
+      component: tools
+      commandLine: |
+        read -p "ENTER a image name and tag for container builds (default is quay.io/wto/web-terminal-exec:next): " TARGET_IMG &&
+        export WEB_TERMINAL_EXEC_IMG=${TARGET_IMG} &&
+        make docker
+      group:
+        kind: build
+  - id: compile
+    exec:
+      label: "Compile Go binary locally"
+      component: tools
+      commandLine: make compile
+      group:
+        kind: build


### PR DESCRIPTION
### What does this PR do?
This Devfile sets up a development environment using the universal developer image, and includes Makefile-based commands

![Screenshot_20250620_192804](https://github.com/user-attachments/assets/265c0b1c-6bc0-4d57-9f5f-6b4cae31474f)


### What issues does this PR fix or reference?
https://github.com/redhat-developer/web-terminal-operator/issues/173

### Is it tested? How?
I created a workspace on workspaces.openshift.com from [this](https://github.com/rohankanojia-forks/web-terminal-exec) repository and tested that all targets are working 
