### PR TITLE
fix(auth): remove check restricting empty UID to handle `kube:admin` bootstrap user scenario

### DIFF
--- a/pkg/operations/operations.go
+++ b/pkg/operations/operations.go
@@ -117,19 +117,20 @@ func GetCurrentWorkspacePod(client kubernetes.Interface) (*corev1.Pod, error) {
 }
 
 func GetCurrentUserUID(token string, clientProvider ClientProvider) (string, error) {
-	uid, err := getCurrentUserUIDFromSelfSubjectReview(token, clientProvider)
+	uid, err := getCurrentUserUIDFromOpenShiftUserAPI(token, clientProvider)
 	if err == nil {
 		return uid, nil
 	}
 
-	// Fall back to the OpenShift User API on clusters where SelfSubjectReview is unavailable.
-	uid, fallbackErr := getCurrentUserUIDFromOpenShiftUserAPI(token, clientProvider)
+	// Fall back to SelfSubjectReview on clusters where the OpenShift User API is unavailable
+	// (e.g. BYO external authentication without user.openshift.io).
+	uid, fallbackErr := getCurrentUserUIDFromSelfSubjectReview(token, clientProvider)
 	if fallbackErr == nil {
 		return uid, nil
 	}
 
 	return "", fmt.Errorf(
-		"failed to get current user information: SelfSubjectReview error: %w; OpenShift User API error: %w",
+		"failed to get current user information: OpenShift User API error: %w; SelfSubjectReview error: %w",
 		err,
 		fallbackErr,
 	)
@@ -149,8 +150,10 @@ func getCurrentUserUIDFromSelfSubjectReview(token string, clientProvider ClientP
 		return "", err
 	}
 
-	// kube:admin / kubeadmin have no Kubernetes UID; empty string is a valid identifier
-	// when AUTHENTICATED_USER_ID is also empty (see config.AuthenticatedUserID).
+	if review.Status.UserInfo.UID == "" {
+		return "", fmt.Errorf("SelfSubjectReview returned empty UID")
+	}
+
 	return review.Status.UserInfo.UID, nil
 }
 
@@ -164,5 +167,7 @@ func getCurrentUserUIDFromOpenShiftUserAPI(token string, clientProvider ClientPr
 		return "", err
 	}
 
+	// kube:admin / kubeadmin have no Kubernetes UID; empty string is a valid identifier
+	// when AUTHENTICATED_USER_ID is also empty (see config.AuthenticatedUserID).
 	return string(userInfo.GetUID()), nil
 }

--- a/pkg/operations/operations.go
+++ b/pkg/operations/operations.go
@@ -149,10 +149,8 @@ func getCurrentUserUIDFromSelfSubjectReview(token string, clientProvider ClientP
 		return "", err
 	}
 
-	if review.Status.UserInfo.UID == "" {
-		return "", fmt.Errorf("SelfSubjectReview returned empty UID")
-	}
-
+	// kube:admin / kubeadmin have no Kubernetes UID; empty string is a valid identifier
+	// when AUTHENTICATED_USER_ID is also empty (see config.AuthenticatedUserID).
 	return review.Status.UserInfo.UID, nil
 }
 
@@ -166,10 +164,5 @@ func getCurrentUserUIDFromOpenShiftUserAPI(token string, clientProvider ClientPr
 		return "", err
 	}
 
-	uid := string(userInfo.GetUID())
-	if uid == "" {
-		return "", fmt.Errorf("OpenShift User API returned empty UID")
-	}
-
-	return uid, nil
+	return string(userInfo.GetUID()), nil
 }

--- a/pkg/operations/operations_test.go
+++ b/pkg/operations/operations_test.go
@@ -76,20 +76,20 @@ func TestGetCurrentUserUID(t *testing.T) {
 			errRegexp: "failed to get current user information",
 		},
 		{
-			name: "Should return error when SelfSubjectReview returns empty UID",
+			name: "Should allow empty UID from SelfSubjectReview for kube:admin",
 			provider: testUserIDClientProvider{
 				userUID: "",
 			},
-			errRegexp: "SelfSubjectReview returned empty UID",
+			expectedUID: "",
 		},
 		{
-			name: "Should return error when OpenShift User API returns empty UID",
+			name: "Should allow empty UID from OpenShift User API for kube:admin",
 			provider: testUserIDClientProvider{
 				returnReviewError: apierrors.NewNotFound(schema.GroupResource{Group: "authentication.k8s.io", Resource: "selfsubjectreviews"}, "self"),
 				userAPIUID:        "",
 				emptyUserAPIUID:   true,
 			},
-			errRegexp: "OpenShift User API returned empty UID",
+			expectedUID: "",
 		},
 	}
 

--- a/pkg/operations/operations_test.go
+++ b/pkg/operations/operations_test.go
@@ -46,9 +46,17 @@ func TestGetCurrentUserUID(t *testing.T) {
 		expectedUID string
 	}{
 		{
-			name: "Should return UID from SelfSubjectReview",
+			name: "Should return UID from OpenShift User API",
 			provider: testUserIDClientProvider{
-				userUID: expectedUID,
+				userAPIUID: expectedUID,
+			},
+			expectedUID: expectedUID,
+		},
+		{
+			name: "Should fall back to SelfSubjectReview when OpenShift User API is unavailable",
+			provider: testUserIDClientProvider{
+				returnUserAPIError: apierrors.NewNotFound(schema.GroupResource{Group: "user.openshift.io", Resource: "users"}, "~"),
+				userUID:            expectedUID,
 			},
 			expectedUID: expectedUID,
 		},
@@ -60,36 +68,28 @@ func TestGetCurrentUserUID(t *testing.T) {
 			errRegexp: "failed to create client to check user info",
 		},
 		{
-			name: "Should fall back to OpenShift User API when SelfSubjectReview is unavailable",
-			provider: testUserIDClientProvider{
-				returnReviewError: apierrors.NewNotFound(schema.GroupResource{Group: "authentication.k8s.io", Resource: "selfsubjectreviews"}, "self"),
-				userAPIUID:        expectedUID,
-			},
-			expectedUID: expectedUID,
-		},
-		{
 			name: "Should return error when both user lookups fail",
 			provider: testUserIDClientProvider{
-				returnReviewError:  apierrors.NewNotFound(schema.GroupResource{Group: "authentication.k8s.io", Resource: "selfsubjectreviews"}, "self"),
 				returnUserAPIError: apierrors.NewNotFound(schema.GroupResource{Group: "user.openshift.io", Resource: "users"}, "~"),
+				returnReviewError:  apierrors.NewNotFound(schema.GroupResource{Group: "authentication.k8s.io", Resource: "selfsubjectreviews"}, "self"),
 			},
 			errRegexp: "failed to get current user information",
 		},
 		{
-			name: "Should allow empty UID from SelfSubjectReview for kube:admin",
+			name: "Should allow empty UID from OpenShift User API for kube:admin",
 			provider: testUserIDClientProvider{
-				userUID: "",
+				userAPIUID:      "",
+				emptyUserAPIUID: true,
 			},
 			expectedUID: "",
 		},
 		{
-			name: "Should allow empty UID from OpenShift User API for kube:admin",
+			name: "Should return error when SelfSubjectReview returns empty UID on fallback",
 			provider: testUserIDClientProvider{
-				returnReviewError: apierrors.NewNotFound(schema.GroupResource{Group: "authentication.k8s.io", Resource: "selfsubjectreviews"}, "self"),
-				userAPIUID:        "",
-				emptyUserAPIUID:   true,
+				returnUserAPIError: apierrors.NewNotFound(schema.GroupResource{Group: "user.openshift.io", Resource: "users"}, "~"),
+				userUID:            "",
 			},
-			expectedUID: "",
+			errRegexp: "SelfSubjectReview returned empty UID",
 		},
 	}
 
@@ -100,8 +100,8 @@ func TestGetCurrentUserUID(t *testing.T) {
 				assert.Error(t, err)
 				assert.Regexp(t, tt.errRegexp, err.Error())
 				if tt.name == "Should return error when both user lookups fail" {
-					assert.Contains(t, err.Error(), "SelfSubjectReview error:")
 					assert.Contains(t, err.Error(), "OpenShift User API error:")
+					assert.Contains(t, err.Error(), "SelfSubjectReview error:")
 				}
 				return
 			}


### PR DESCRIPTION


### What does this PR do?

Fixes a regression introduced in #134 where web-terminal-exec rejects users with an empty Kubernetes UID, breaking web terminal auth for bootstrap `kube:admin` on clusters where `oc whoami` returns `kube:admin`.

#134 added `SelfSubjectReview` (needed for WTO-399 / external auth), but also added:
```go
if review.Status.UserInfo.UID == "" {
    return "", fmt.Errorf("SelfSubjectReview returned empty UID")
}
```

Before #134, we already allowed empty UIDs, the User API path simply returned string(userInfo.GetUID()) with no blank check, so "" was valid and "" == "" auth succeeded for kube:admin (see https://github.com/openshift/origin/issues/24950).

After #134, the new checks fail auth before we reach that comparison.
<img width="1907" height="337" alt="Screenshot 2026-06-25 at 14 15 45" src="https://github.com/user-attachments/assets/07457445-5e27-4e39-bf0d-0512be84bf63" />

This PR restores that behavior with two changes:

  1. Reordered UID lookup — try the OpenShift User API first, then fall back to SelfSubjectReview only
     when the User API is unavailable (e.g. BYO external authentication without user.openshift.io). This
     matches pre-#134 ordering and lets kube:admin resolve via the User API before hitting the stricter
     fallback path.

  2. Partial empty-UID check — allow an empty UID from the OpenShift User API (valid for kube:admin /
     kubeadmin when AUTHENTICATED_USER_ID is also empty), but keep the empty-UID rejection on the
     SelfSubjectReview fallback path so external-auth users without a UID still fail clearly rather than
     silently authenticating.


### What issues does this PR fix or reference?
fixes issue found during pre-release-testing, `kube:admin` users were unable to open terminal 

### Is it tested? How?
Verified on aws clusterbot CI cluster (oc whoami = `kube:admin`):

SelfSubjectReview: `userInfo.username=kube:admin`, no uid field
User API (~): `metadata.name=kube:admin`, no metadata.uid

Bootstrap `kube:admin` has no Kubernetes UID.

<!-- Please provide instructions here how reviewer can test your changes if applicable -->
1. Deploy WTO with current staging RC
2. Open the web terminal as `kube:admin`
3. You'll see error
4. Patch Web Terminal Exec template with this image based on this PR
```
oc patch devworkspacetemplate web-terminal-exec -n "${NS:-openshift-operators}" --type='json'  -p='[{"op":"replace","path":"/spec/components/0/container/image","value":"docker.io/rohankanojia/web-terminal-exec:fix-kube-admin-empty-uid"}]'
```
5. Delete DevWorkspace for old terminal and then open again
6. Terminal should load now as expected
