### PR TITLE
chore (deps) : Update project to go 1.26.5

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -25,7 +25,7 @@ jobs:
       name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: '1.25.7'
+        go-version: '1.26.5'
     -
       name: Check out code into the Go module directory
       uses: actions/checkout@v4

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9/go-toolset
-FROM registry.access.redhat.com/ubi9/go-toolset:1.25.7-1772454089 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5-1784190466 AS builder
 ENV GOPATH=/go/
 USER root
 WORKDIR /web-terminal-exec

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,7 +18,7 @@ COPY . .
 RUN make compile
 
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi9-minimal
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.7-1771346502
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1784092902
 RUN microdnf -y update && microdnf clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages"
 WORKDIR /
 COPY --from=builder /web-terminal-exec/_output/bin/web-terminal-exec /usr/local/bin/web-terminal-exec

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-developer/web-terminal-exec
 
-go 1.25.7
+go 1.26.5
 
 require (
 	github.com/sirupsen/logrus v1.9.1


### PR DESCRIPTION
### What does this PR do?

Bumps the Go version and base images to the latest releases:
- Updates the Go version to `1.26.5` in `go.mod` and PR check workflows.
- Updates the `ubi9/go-toolset` builder image to `1.26.5-1784190466`.
- Updates the `ubi9/ubi-minimal` runtime base image to `9.8-1784092902` in the `Dockerfile`.

### What issues does this PR fix or reference?

None.

### Is it tested? How?
<!-- Please provide instructions here how reviewer can test your changes if applicable -->

Verified that the Go version and container base image tag syntax is updated across all relevant files correctly. The standard GitHub Actions CI will build the container image and execute unit/integration tests with the new Go and ubi-minimal environments.

---

Signed-off-by: Rohan Kumar <rokumar@redhat.com>
Assisted-by: opencode <big-pickle>
